### PR TITLE
Update Data Latency Alerts DAG schedule to run daily at 1:00 PM IST

### DIFF
--- a/dags/data_latency_alerts_dag.py
+++ b/dags/data_latency_alerts_dag.py
@@ -7,7 +7,7 @@ This DAG orchestrates data latency monitoring by:
 3. Converting results to XLSX format
 4. Sending appropriate Slack notifications (success or failure) with client-specific routing
 
-The DAG is scheduled to run once daily at 1:30 PM IST.
+The DAG is scheduled to run once daily at 1:00 PM IST.
 
 FEATURES:
 - Rich Slack notifications with professional formatting
@@ -92,7 +92,7 @@ else:
 
 # DAG Configuration
 DAG_ID = "data_latency_alerts"
-SCHEDULE_INTERVAL = "0 8 * * *"  # 1:30 PM IST (8:00 UTC)
+SCHEDULE_INTERVAL = "30 7 * * *"  # 1:00 PM IST (7:30 UTC)
 DEFAULT_ARGS = {
     "owner": "data-engineering",
     "depends_on_past": False,


### PR DESCRIPTION
The DAG has been consistently failing around 1:30 PM due to resource contention, as multiple client DAGs are scheduled to run around the same time.

To reduce system load and avoid overlap, we are updating the schedule to run at 1:00 PM instead. This change is intended to improve stability and prevent recurring latency-related failures.