### PR TITLE
Add Daton, BQ table monitoring with cross-region metadata collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,251 +2,215 @@
 
 # Data Latency Alerts
 
-A streamlined Airflow DAG that monitors data freshness by integrating with BigQuery Data Transfer Service and sends rich Slack notifications with XLSX reports in threaded conversations.
+An Airflow DAG that monitors data freshness across multiple BigQuery projects and regions. It detects tables exceeding latency thresholds and sends rich Slack notifications with XLSX reports routed to client-specific channels.
 
-## 🏗️ Architecture Overview
+## Architecture
 
-Simple and efficient workflow:
+```mermaid
+flowchart TB
+  subgraph metadata ["Task 1: collect_metadata"]
+    direction TB
+    P1["insightsprod"]
+    P2["pulse-wellbeam"]
+    P3["pulse-instanthydration"]
+    P4["pulse-mantasleep"]
+    P5["pulse-javvycoffee"]
+    P6["pulse-nexus"]
 
-1. **BigQuery Data Transfer Service**: Triggers pre-configured transfer job and waits for completion
-2. **Direct Query**: Simple `SELECT *` from processed results table
-3. **XLSX Generation**: Converts results to XLSX with timestamp handling
-4. **Rich Slack Notifications**: Professional block formatting with threaded file attachments
+    R1["region-us-central1"]
+    R2["region-us"]
 
-## ✨ Features
+    P1 & P2 & P3 & P4 & P5 & P6 --> R1 & R2
 
-- **🔄 Data Transfer Integration**: Automated BigQuery DTS job triggering
-- **📊 Smart XLSX Reports**: Automatic timestamp conversion for JSON serialization
-- **🧵 Threaded File Attachments**: Reports sent as threaded replies for organized conversations
-- **🎨 Rich Slack Blocks**: Professional notifications with buttons linking to Airflow logs
-- **🔧 Flexible Channels**: Support for multiple comma-separated Slack channels
-- **⚡ Error Handling**: Context-aware failure notifications with direct links to task logs
-- **🏷️ Organized Variables**: All configuration uses `LATENCY_ALERTS__` prefix
+    R1 & R2 -->|"TABLE_STORAGE\nSCHEMATA_OPTIONS"| Staging["Staging Tables\nin BigQuery"]
+  end
 
-## 🚀 Quick Start
+  subgraph analysis ["Task 2: run_latency_sql"]
+    Staging --> Query["query.sql\nPattern matching\nThreshold evaluation\nDaton enrichment"]
+    Query --> Results["raw_table_latency_failure_details"]
+  end
 
-### 1. Configure Airflow Variables
+  subgraph reporting ["Tasks 3-5"]
+    Results --> Check["run_latency_check"]
+    Check --> XLSX["convert_to_xlsx"]
+    XLSX --> Slack["send_notification"]
+  end
 
-All variables use the `LATENCY_ALERTS__` prefix for organization:
-
-```bash
-# Required Variables
-LATENCY_ALERTS__BQ_DTS_CONFIG_ID = your-transfer-config-id
-
-# Core Configuration (with defaults)
-LATENCY_ALERTS__PROJECT_NAME = insightsprod
-LATENCY_ALERTS__AUDIT_DATASET_NAME = edm_insights_metadata  
-LATENCY_ALERTS__BIGQUERY_LOCATION = us-central1
-
-# Slack Configuration
-LATENCY_ALERTS__SLACK_CHANNELS = #data-alerts,#monitoring
-
-# Optional
-LATENCY_ALERTS__AIRFLOW_BASE_URL = https://your-airflow-instance.com
+  Slack --> Default["Default Channel"]
+  Slack --> Client["Client Channels\nvia regex routing"]
 ```
 
-### 2. Set Up Connections
+## How It Works
 
-**BigQuery Connection**: `data_latency_alerts__conn_id`
+### Cross-Region Metadata Collection
+
+BigQuery `INFORMATION_SCHEMA` views are region-scoped — a job in `us-central1` cannot access `region-us` metadata. To solve this, the DAG's first task uses Python with `BigQueryHook` to query each project and region combination separately (with the correct job location), then writes the combined results to staging tables in `us-central1`.
+
+This runs in parallel using `ThreadPoolExecutor` (6 workers) and gracefully skips project/region combinations that don't exist (404 errors are caught and logged).
+
+### Latency Evaluation
+
+The SQL query (`query.sql`) evaluates latency by:
+
+1. Reading pre-collected metadata from staging tables
+2. Filtering to monitored schemas: `_prod_raw`, `daton`, `BQ`, and `nexus_gds_raw`
+3. Applying exclusions (specific datasets and project-scoped exclusions)
+4. Matching tables against configurable latency patterns from `raw_table_latency_thresholds`
+5. Applying a 24-hour default threshold for daton/BQ tables that don't match any pattern
+6. Enriching results with Daton source metadata (platform, status, last error)
+
+### Client-Specific Slack Routing
+
+Alerts are routed to client-specific Slack channels using regex pattern matching on `table_schema`. Each result row is tested against configured patterns, and matching rows are sent to the appropriate channel. All results are always sent to the default channel as well.
+
+## DAG Workflow
+
+**Schedule**: Daily at 1:00 PM IST (7:30 UTC)
+
+```mermaid
+flowchart LR
+  T1["collect_metadata\n(PythonOperator)"]
+  T2["run_latency_sql\n(BigQueryInsertJobOperator)"]
+  T3["run_latency_check\n(PythonOperator)"]
+  T4["convert_to_xlsx\n(PythonOperator)"]
+  T5["send_notification\n(PythonOperator)"]
+
+  T1 --> T2 --> T3 --> T4 --> T5
+  T1 & T2 & T3 & T4 -.->|"ALL_DONE trigger"| T5
+```
+
+| Task | Type | Description |
+|------|------|-------------|
+| `collect_metadata` | PythonOperator | Queries `INFORMATION_SCHEMA.TABLE_STORAGE` and `SCHEMATA_OPTIONS` across all projects and regions, writes to staging tables |
+| `run_latency_sql` | BigQueryInsertJobOperator | Runs `query.sql` against staging tables, writes violations to `raw_table_latency_failure_details` |
+| `run_latency_check` | PythonOperator | Reads the violation results table into memory |
+| `convert_to_xlsx` | PythonOperator | Converts results to XLSX with auto-adjusted column widths |
+| `send_notification` | PythonOperator | Sends Slack notifications with routed results; handles both success and failure cases |
+
+The `send_notification` task uses `trigger_rule=ALL_DONE` so it runs even if upstream tasks fail, sending a failure alert instead.
+
+## Configuration
+
+### Airflow Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LATENCY_ALERTS__PROJECT_NAME` | JSON array of GCP projects to monitor | `["insightsprod"]` |
+| `LATENCY_ALERTS__AUDIT_DATASET_NAME` | Dataset for metadata and staging tables | `edm_insights_metadata` |
+| `LATENCY_ALERTS__BIGQUERY_LOCATION` | BigQuery job location for analysis query | `us-central1` |
+| `LATENCY_ALERTS__SLACK_CHANNELS` | JSON channel routing config (see below) | Required |
+| `LATENCY_ALERTS__AIRFLOW_BASE_URL` | Base URL for Airflow log links in Slack | Auto-detected |
+
+### Slack Channel Configuration
+
+`LATENCY_ALERTS__SLACK_CHANNELS` is a JSON object where keys are regex patterns matched against `table_schema`, and values are Slack channel IDs. A `default` key is required.
+
+```json
+{
+  "3642|nexus_gds_raw": "C07178BP4G7",
+  "4997|poshpeanut": "C07SJE04J6T",
+  "4634|ridge": "C0A443TJHT4",
+  "4927|instanthydrati": "C0A87NP1GLR",
+  "5363|trueseamoss": "C0AFKSU9Z0V",
+  "5622|warmies": "C0AFKSU9Z0V",
+  "5667|homefield": "C0AFKSU9Z0V",
+  "default": "C06QY1KQJJG"
+}
+```
+
+Pattern keys use regex `search` — `4927|instanthydrati` matches any `table_schema` containing `4927` OR `instanthydrati` (handles truncated daton dataset names).
+
+### Airflow Connections
+
+**BigQuery**: `data_latency_alerts__conn_id`
 - Connection Type: Google Cloud
-- Service account with: BigQuery Data Viewer, BigQuery Job User, BigQuery Data Transfer Admin
+- Required roles: BigQuery Data Viewer, BigQuery Job User
 
-**Slack Connection**: `slack_default`
-- Connection Type: Slack Webhook
-- Password: Bot User OAuth Token (xoxb-...)
+**Slack**: `slack_default`
+- Connection Type: Slack
+- Password: Bot User OAuth Token (`xoxb-...`)
 - Required scopes: `chat:write`, `files:write`, `channels:read`, `groups:read`
 
-### 3. Deploy
+## Monitored Dataset Types
 
-The DAG automatically deploys when you push to the main branch.
+| Schema Pattern | Source | Threshold |
+|----------------|--------|-----------|
+| `%_prod_raw` | Raw data ingestion tables | Per-pattern from `raw_table_latency_thresholds` |
+| `%daton%` | Daton connector tables | Per-pattern, or 24h default |
+| `%BQ%` | BigQuery custom tables | Per-pattern, or 24h default |
+| `nexus_gds_raw` | Nexus GDS raw data | Per-pattern from `raw_table_latency_thresholds` |
 
-## 📋 DAG Workflow
+### Exclusion Mechanisms
 
-**Schedule**: Once daily at 11:30 AM IST
+1. **Dataset-level exclusions**: Hardcoded in `query.sql` (`table_schema NOT IN (...)`)
+2. **Project-scoped exclusions**: `NOT (source_project_id = 'X' AND table_schema = 'Y')`
+3. **Label-based exclusions**: Datasets with BigQuery label `latency_check_ignore=true`
+4. **Table-level ignore list**: `insightsprod.edm_insights_metadata.ignore_latency_tables_list`
 
-| Task | Description |
-|------|-------------|
-| `start_data_transfer` | Triggers BigQuery DTS job and waits for completion |
-| `run_latency_check` | Queries `raw_table_latency_failure_details` table |
-| `convert_to_xlsx` | Converts results to XLSX with proper timestamp handling |
-| `send_notification` | Sends success/failure notifications with rich formatting |
+## BigQuery Tables
 
-## 📊 Data Flow
+### Metadata Tables (read-only)
 
-```mermaid
-graph LR
-    A[BigQuery DTS] --> B[Transfer Complete]
-    B --> C[Query Results Table]
-    C --> D[Convert to XLSX]
-    D --> E[Slack Notification]
-    E --> F[Threaded File Reply]
-    
-    G[Any Task Failure] --> H[Failure Notification]
-```
+| Table | Purpose |
+|-------|---------|
+| `edm_insights_metadata.raw_table_latency_thresholds` | Pattern-to-threshold mapping |
+| `edm_insights_metadata.ignore_latency_tables_list` | Explicit table ignore list |
+| `pulse_metadata.gcp_postgres_daton_public_source_tables` | Daton source table metadata |
+| `pulse_metadata.gcp_postgres_daton_public_source` | Daton source metadata |
+| `pulse_metadata.gcp_postgres_daton_public_last_job_stats` | Daton job error details |
 
-## 🎯 Slack Notifications
+### Staging Tables (written by DAG)
 
-### Success Notifications
-- **📄 XLSX File**: Latency violations with rich context (sent as threaded reply)
-- **✅ No Violations**: Clean success message
-- **🔗 Action Buttons**: Direct links to Airflow DAG and task logs
+| Table | Written By | Read By |
+|-------|-----------|---------|
+| `edm_insights_metadata._latency_staging_table_storage` | `collect_metadata` task | `query.sql` |
+| `edm_insights_metadata._latency_staging_dataset_labels` | `collect_metadata` task | `query.sql` |
+| `edm_insights_metadata.raw_table_latency_failure_details` | `run_latency_sql` task | `run_latency_check` task |
 
-### Failure Notifications
-- **🚨 Context-Aware Messages**: Different messages for transfer, query, or conversion failures
-- **📋 Error Details**: Task-specific error information
-- **🔗 Log Access**: Direct buttons to failed task logs
-
-### Threaded File Attachments
-
-The system sends report attachments as threaded replies to keep conversations organized:
+## SQL Query Flow
 
 ```mermaid
-sequenceDiagram
-    participant DAG as Airflow DAG
-    participant Utils as Utils Module
-    participant Slack as Slack API
-    
-    DAG->>Utils: send_latency_report_to_slack()
-    Note over Utils: Process violations & build summary
-    
-    Utils->>Utils: send_slack_message_with_blocks()
-    Utils->>Slack: POST /chat.postMessage (summary blocks)
-    Slack-->>Utils: Response with message timestamp
-    Note over Utils: Store timestamp for threading
-    
-    alt violations_count > 0
-        Utils->>Utils: send_slack_file() with thread_ts
-        Utils->>Slack: POST /files.upload (with thread_ts)
-        Note over Slack: File appears as threaded reply
-        Slack-->>Utils: File upload response
-    end
-    
-    Utils-->>DAG: Complete with both results
+flowchart TB
+  Staging["_latency_staging_table_storage"] --> Dedup["deduped_table_storage\nFilter schemas, apply exclusions,\ndedup across projects"]
+  Labels["_latency_staging_dataset_labels"] --> Match
+  Patterns["raw_table_latency_thresholds"] --> Match
+  IgnoreList["ignore_latency_tables_list"] --> Match
+  Dedup --> Match["matched_tables\nLEFT JOIN patterns\nCOALESCE threshold with 24h default\nApply latency check"]
+  Match --> DedupMatch["deduped_matched_tables\nROW_NUMBER per schema+table"]
+  DedupMatch --> Final["Final SELECT\nJoin with Daton source metadata\nOrder by hours_since_last_update DESC"]
 ```
 
-### Block Templates
-- `latency_report_success`: For violations found
-- `latency_report_no_violations`: For clean runs
-- `bigquery_failure`: For BigQuery-specific errors
-- `slack_failure`: For Slack API errors
-
-## ⚙️ Configuration Details
-
-### Required Table Structure
-
-The DAG expects this table to exist after data transfer:
-```sql
-`{PROJECT_NAME}.{AUDIT_DATASET_NAME}.raw_table_latency_failure_details`
-```
-
-### Variable Reference
-
-| Variable | Description | Default | Required |
-|----------|-------------|---------|----------|
-| `LATENCY_ALERTS__BQ_DTS_CONFIG_ID` | Transfer config ID (must be in us-central1) | None | ✅ |
-| `LATENCY_ALERTS__PROJECT_NAME` | GCP project name | `insightsprod` | ❌ |
-| `LATENCY_ALERTS__AUDIT_DATASET_NAME` | Metadata dataset | `edm_insights_metadata` | ❌ |
-| `LATENCY_ALERTS__BIGQUERY_LOCATION` | BigQuery location | `us-central1` | ❌ |
-| `LATENCY_ALERTS__SLACK_CHANNELS` | Comma-separated channels | `#slack-bot-test` | ❌ |
-| `LATENCY_ALERTS__AIRFLOW_BASE_URL` | Base URL for DAG links | Auto-detected | ❌ |
-
-### Multiple Slack Channels
-
-Configure multiple channels with comma separation:
-```bash
-LATENCY_ALERTS__SLACK_CHANNELS = #data-alerts,#monitoring,#critical-alerts
-```
-
-## 📁 Project Structure
+## Project Structure
 
 ```
 data-latency-alerts/
 ├── dags/
-│   ├── data_latency_alerts_dag.py    # Main DAG file
-│   ├── utils.py                      # Utility functions
+│   ├── data_latency_alerts_dag.py    # DAG definition and task callables
+│   ├── query.sql                     # Latency evaluation SQL
+│   ├── utils.py                      # BigQuery, Slack, and metadata utilities
 │   └── slack_blocks.json             # Slack block templates
-├── config/
-│   └── README.md                     # Configuration guide
-├── composer/                         # Cloud Composer environment
-└── requirements.txt                  # Python dependencies
+├── composer/
+│   └── data-latency-alert/
+│       └── requirements.txt          # Python dependencies for Composer
+├── .github/
+│   └── workflows/
+│       └── deploy-dags.yml           # CI/CD deployment to Cloud Composer
+└── README.md
 ```
 
-## 🔧 Development
+## Deployment
 
-### Local Development
+DAGs automatically deploy to Cloud Composer when changes are pushed to `main` (paths: `dags/**` or the workflow file). The GitHub Actions workflow syncs the `dags/` directory to the Composer DAG bucket under a `data-latency-alerts/` subfolder.
 
-```bash
-# Clone repository
-git clone <your-repo-url>
-cd data-latency-alerts
+Manual deployment is also available via `workflow_dispatch` with optional bucket path or environment name inputs.
 
-# Install dependencies
-pip install -r requirements.txt
+## Troubleshooting
 
-# Set up environment variables (for testing)
-export LATENCY_ALERTS__PROJECT_NAME="your-project"
-export LATENCY_ALERTS__AUDIT_DATASET_NAME="your-dataset"
-```
-
-### Key Dependencies
-
-```
-apache-airflow==2.7.0
-apache-airflow-providers-google==10.10.0
-apache-airflow-providers-slack==7.3.0
-pandas==2.0.3
-openpyxl==3.1.2
-jinja2==3.1.2
-google-cloud-bigquery-datatransfer==3.11.0
-```
-
-## 🚨 Troubleshooting
-
-### Common Issues
-
-| Issue | Solution |
-|-------|----------|
-| **Transfer Config Not Found** | Verify `LATENCY_ALERTS__BQ_DTS_CONFIG_ID` and ensure config exists in `us-central1` |
-| **Permission Errors** | Check service account has BigQuery Data Transfer Admin role |
-| **Slack API Errors** | Verify connection scopes and bot permissions |
-| **Table Not Found** | Ensure data transfer creates the expected results table |
-| **Timestamp Serialization** | Fixed automatically - timestamps converted to ISO strings |
-
-### Debug Steps
-
-1. **Check Variables**: Admin → Variables in Airflow UI
-2. **Verify Connections**: Admin → Connections
-3. **Review Logs**: Click direct log buttons in Slack notifications
-4. **Test Transfer**: Manually run transfer config in BigQuery console
-
-## 🔄 Migration Notes
-
-If migrating from a previous version:
-
-1. **Update Variables**: Add `LATENCY_ALERTS__` prefix to all variables
-2. **Remove Old Files**: Delete unused test files and reports
-3. **Update Connections**: Ensure proper scopes and permissions
-4. **Verify Transfer Config**: Must be in `us-central1` location
-
-## 📈 Performance
-
-- **Execution Time**: ~2-5 minutes including transfer wait time
-- **Resource Efficiency**: Uses deferrable operators
-- **Scalability**: Handles large result sets with streaming
-- **Cost Optimization**: Single transfer + simple query approach
-
-## 🤝 Contributing
-
-1. Fork the repository
-2. Create feature branch: `git checkout -b feature-name`
-3. Commit changes: `git commit -am 'Add feature'`
-4. Push branch: `git push origin feature-name`
-5. Create Pull Request
-
-## 📄 License
-
-This project is licensed under the MIT License.
-
----
-
-**Need Help?** Check the [configuration guide](config/README.md) or review the troubleshooting section above.
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `NotFound: TABLE_STORAGE` | Project has no datasets in that region | Handled automatically — logged as warning and skipped |
+| `LEFT ANTISEMI JOIN` error | `NOT EXISTS` with `LIKE` condition | Use pre-computed CTE with equality join instead |
+| Staging table not found | `collect_metadata` task failed or didn't run | Check task logs; ensure BigQuery connection has write access to audit dataset |
+| Missing daton/BQ tables | Dataset not matching schema filters | Verify `table_schema` matches `%daton%` or `%BQ%` patterns |
+| Slack routing not working | Pattern doesn't match `table_schema` | Test regex against actual `table_schema` values; use truncated prefixes for daton names |
+| Zero violations but tables are stale | Table excluded by labels or ignore list | Check `latency_check_ignore` label and `ignore_latency_tables_list` |

--- a/README.md
+++ b/README.md
@@ -189,9 +189,6 @@ data-latency-alerts/
 │   ├── query.sql                     # Latency evaluation SQL
 │   ├── utils.py                      # BigQuery, Slack, and metadata utilities
 │   └── slack_blocks.json             # Slack block templates
-├── composer/
-│   └── data-latency-alert/
-│       └── requirements.txt          # Python dependencies for Composer
 ├── .github/
 │   └── workflows/
 │       └── deploy-dags.yml           # CI/CD deployment to Cloud Composer

--- a/dags/data_latency_alerts_dag.py
+++ b/dags/data_latency_alerts_dag.py
@@ -2,10 +2,11 @@
 Data Latency Alerts DAG
 
 This DAG orchestrates data latency monitoring by:
-1. Running latency SQL query to build the failure details table
-2. Executing latency check query on processed data
-3. Converting results to XLSX format
-4. Sending appropriate Slack notifications (success or failure) with client-specific routing
+1. Collecting TABLE_STORAGE and SCHEMATA_OPTIONS metadata across all projects and regions
+2. Running latency SQL query to build the failure details table
+3. Executing latency check query on processed data
+4. Converting results to XLSX format
+5. Sending appropriate Slack notifications (success or failure) with client-specific routing
 
 The DAG is scheduled to run once daily at 1:00 PM IST.
 
@@ -51,6 +52,7 @@ current_dir = Path(__file__).parent
 sys.path.insert(0, str(current_dir))
 
 from utils import (
+    collect_cross_region_metadata,
     convert_results_to_xlsx,
     execute_bigquery_latency_check,
     send_failure_notification,
@@ -103,6 +105,25 @@ DEFAULT_ARGS = {
     "retry_delay": timedelta(minutes=0),
     "catchup": False,
 }
+
+def collect_metadata(**context):
+    """
+    Collect TABLE_STORAGE and SCHEMATA_OPTIONS from all projects and regions,
+    then write to staging tables for the downstream SQL analysis query.
+    """
+    stats = collect_cross_region_metadata(
+        projects=PROJECTS_ARRAY,
+        dest_project=PROJECT_NAME,
+        dest_dataset=AUDIT_DATASET_NAME,
+        gcp_conn_id=BIGQUERY_CONN_ID,
+    )
+    logging.info(
+        "📊 Metadata collection complete: %d storage rows, %d label rows",
+        stats["table_storage_rows"],
+        stats["dataset_labels_rows"],
+    )
+    return stats
+
 
 def run_latency_check(**context):
     """
@@ -246,7 +267,14 @@ with DAG(
     doc_md=__doc__,
 ) as dag:
 
-    # Task 1: Run latency SQL to rebuild the latency failure table
+    # Task 1: Collect metadata from all projects and regions into staging tables
+    collect_metadata_task = PythonOperator(
+        task_id="collect_metadata",
+        python_callable=collect_metadata,
+        provide_context=True,
+    )
+
+    # Task 2: Run latency SQL to rebuild the latency failure table
     run_latency_sql_task = BigQueryInsertJobOperator(
         task_id="run_latency_sql",
         gcp_conn_id=BIGQUERY_CONN_ID,
@@ -265,30 +293,30 @@ with DAG(
         location=LOCATION,
     )
 
-    # Task 2: Run latency check on processed data
+    # Task 3: Run latency check on processed data
     latency_check_task = PythonOperator(
         task_id="run_latency_check",
         python_callable=run_latency_check,
         provide_context=True,
     )
 
-    # Task 3: Convert results to XLSX
+    # Task 4: Convert results to XLSX
     convert_xlsx_task = PythonOperator(
         task_id="convert_to_xlsx",
         python_callable=convert_to_xlsx,
         provide_context=True,
     )
 
-    # Task 4: Send notification (handles both success and failure)
+    # Task 5: Send notification (handles both success and failure)
     notify_task = PythonOperator(
         task_id="send_notification",
         python_callable=send_notification,
         provide_context=True,
-        trigger_rule=TriggerRule.ALL_DONE,  # Run regardless of upstream success/failure
+        trigger_rule=TriggerRule.ALL_DONE,
     )
 
     # Set up task dependencies
-    run_latency_sql_task >> latency_check_task >> convert_xlsx_task >> notify_task
+    collect_metadata_task >> run_latency_sql_task >> latency_check_task >> convert_xlsx_task >> notify_task
 
     # Ensure notification runs even if upstream tasks fail
-    [run_latency_sql_task, latency_check_task, convert_xlsx_task] >> notify_task
+    [collect_metadata_task, run_latency_sql_task, latency_check_task, convert_xlsx_task] >> notify_task

--- a/dags/query.sql
+++ b/dags/query.sql
@@ -8,16 +8,11 @@ patterns AS (
 ),
 
 -- ---------------------------------------------------------------------
--- TABLE_STORAGE across dynamic projects
+-- TABLE_STORAGE (pre-collected across all projects and regions)
 -- ---------------------------------------------------------------------
 table_storage_all AS (
-{% for project in var.json.LATENCY_ALERTS__PROJECT_NAME %}
-  SELECT
-    '{{ project }}' AS source_project_id,
-    *
-  FROM `{{ project }}.region-us-central1.INFORMATION_SCHEMA.TABLE_STORAGE`
-  {% if not loop.last %}UNION ALL{% endif %}
-{% endfor %}
+  SELECT *
+  FROM `insightsprod.edm_insights_metadata._latency_staging_table_storage`
 ),
 
 -- ---------------------------------------------------------------------
@@ -33,24 +28,34 @@ deduped_table_storage AS (
   WHERE deleted = FALSE
     AND (
       table_schema LIKE '%_prod_raw'
+      OR table_schema LIKE '%daton%'
+      OR UPPER(table_schema) LIKE '%BQ%'
       OR table_schema IN ('nexus_gds_raw')
     )
+    AND table_schema NOT IN (
+      'daton_healthycell_kr',
+      'DatonPearlWestGroup',
+      'IH_Daton',
+      'daton_eskiin_custom_backup',
+      'lhappyinnov_daton_backup',
+      'marketdefense_daton_staging',
+      'wellbeam_daton_backup'
+    )
+    AND NOT (source_project_id = 'insightsprod' AND table_schema = 'Manta_Daton')
+    AND NOT (source_project_id = 'insightsprod' AND table_schema = 'daton_instanthydrati')
+    AND NOT (source_project_id = 'pulse-instanthydration' AND table_schema = 'daton_instanthydrati')
+    AND NOT (source_project_id = 'insightsprod' AND table_schema = 'daton_javvycofee')
+    AND NOT (source_project_id = 'insightsprod' AND table_schema = 'wellbeam_daton')
+    AND table_name != 'daton_metadata'
   GROUP BY table_schema, table_name
 ),
 
 -- ---------------------------------------------------------------------
--- Dataset labels (ignore latency_check_ignore=true)
+-- Dataset labels (pre-collected, ignore latency_check_ignore=true)
 -- ---------------------------------------------------------------------
 dataset_labels AS (
-{% for project in var.json.LATENCY_ALERTS__PROJECT_NAME %}
-  SELECT
-    '{{ project }}' AS project_id,
-    schema_name
-  FROM `{{ project }}.region-us-central1.INFORMATION_SCHEMA.SCHEMATA_OPTIONS`
-  WHERE option_name = 'labels'
-    AND option_value LIKE '%"latency_check_ignore", "true"%'
-  {% if not loop.last %}UNION ALL{% endif %}
-{% endfor %}
+  SELECT DISTINCT schema_name
+  FROM `insightsprod.edm_insights_metadata._latency_staging_dataset_labels`
 ),
 
 -- ---------------------------------------------------------------------
@@ -64,14 +69,14 @@ table_labels AS (
 ),
 
 -- ---------------------------------------------------------------------
--- Latency evaluation
+-- Latency evaluation: single-pass pattern matching with daton fallback
 -- ---------------------------------------------------------------------
 matched_tables AS (
   SELECT
     dts.table_schema,
     dts.table_name,
     DATETIME(dts.storage_last_modified_time, "Asia/Kolkata") AS last_update,
-    p.latency_threshold,
+    COALESCE(p.latency_threshold, 24) AS latency_threshold,
     TIMESTAMP_DIFF(
       DATETIME(CURRENT_TIMESTAMP(), "Asia/Kolkata"),
       DATETIME(dts.storage_last_modified_time, "Asia/Kolkata"),
@@ -79,22 +84,23 @@ matched_tables AS (
     ) AS hours_since_last_update,
     dts.present_in_projects
   FROM deduped_table_storage dts
-  CROSS JOIN patterns p
+  LEFT JOIN patterns p
+    ON LOWER(dts.table_name) LIKE p.table_pattern
+   AND p.latency_threshold IS NOT NULL
   LEFT JOIN dataset_labels dl
     ON dl.schema_name = dts.table_schema
   LEFT JOIN table_labels tl
     ON tl.table_schema = dts.table_schema
    AND tl.table_name = dts.table_name
   WHERE
-    LOWER(dts.table_name) LIKE p.table_pattern
-    AND p.latency_threshold IS NOT NULL
+    (p.table_pattern IS NOT NULL OR dts.table_schema LIKE '%daton%' OR UPPER(dts.table_schema) LIKE '%BQ%')
+    AND dl.schema_name IS NULL
+    AND tl.table_name IS NULL
     AND DATETIME(dts.storage_last_modified_time, "Asia/Kolkata")
         < TIMESTAMP_SUB(
             DATETIME(CURRENT_TIMESTAMP(), "Asia/Kolkata"),
-            INTERVAL p.latency_threshold HOUR
+            INTERVAL COALESCE(p.latency_threshold, 24) HOUR
           )
-    AND dl.schema_name IS NULL
-    AND tl.table_name IS NULL
 ),
 
 -- ---------------------------------------------------------------------

--- a/dags/utils.py
+++ b/dags/utils.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote
 
@@ -20,7 +21,164 @@ import pandas as pd
 from airflow.models import Variable
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.providers.slack.hooks.slack import SlackHook
+from google.cloud.bigquery import LoadJobConfig, WriteDisposition
 from jinja2 import Template
+
+REGIONS: List[Tuple[str, str]] = [
+    ("region-us-central1", "us-central1"),
+    ("region-us", "US"),
+]
+
+_TABLE_STORAGE_SQL = """
+SELECT
+  '{project}' AS source_project_id,
+  table_schema,
+  table_name,
+  storage_last_modified_time,
+  deleted
+FROM `{project}.{region_path}.INFORMATION_SCHEMA.TABLE_STORAGE`
+"""
+
+_DATASET_LABELS_SQL = """
+SELECT DISTINCT schema_name
+FROM `{project}.{region_path}.INFORMATION_SCHEMA.SCHEMATA_OPTIONS`
+WHERE option_name = 'labels'
+  AND option_value LIKE '%"latency_check_ignore", "true"%'
+"""
+
+
+def _run_bq_query(
+    gcp_conn_id: str,
+    job_location: str,
+    sql: str,
+    description: str,
+) -> Optional[pd.DataFrame]:
+    """Execute a single BigQuery query, returning a DataFrame or None on 404."""
+    try:
+        hook = BigQueryHook(
+            gcp_conn_id=gcp_conn_id,
+            location=job_location,
+            use_legacy_sql=False,
+        )
+        df = hook.get_pandas_df(sql=sql, dialect="standard")
+        logging.info("✅ %s — %d rows", description, len(df))
+        return df
+    except Exception as exc:
+        if "NotFound" in type(exc).__name__ or "404" in str(exc):
+            logging.warning("⚠️ %s — not found, skipping", description)
+            return None
+        raise
+
+
+def collect_cross_region_metadata(
+    projects: List[str],
+    dest_project: str,
+    dest_dataset: str,
+    gcp_conn_id: str,
+    max_workers: int = 6,
+) -> Dict[str, int]:
+    """
+    Collect TABLE_STORAGE and SCHEMATA_OPTIONS from all project x region
+    combinations and write the results to staging tables in BigQuery.
+
+    Returns dict with row counts for each staging table.
+    """
+    logging.info(
+        "🔄 Collecting metadata for %d project(s) across %d region(s)",
+        len(projects),
+        len(REGIONS),
+    )
+
+    storage_futures: Dict[Any, str] = {}
+    labels_futures: Dict[Any, str] = {}
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for project in projects:
+            for region_path, job_location in REGIONS:
+                tag = f"{project}/{region_path}"
+
+                storage_futures[
+                    executor.submit(
+                        _run_bq_query,
+                        gcp_conn_id,
+                        job_location,
+                        _TABLE_STORAGE_SQL.format(project=project, region_path=region_path),
+                        f"TABLE_STORAGE {tag}",
+                    )
+                ] = tag
+
+                labels_futures[
+                    executor.submit(
+                        _run_bq_query,
+                        gcp_conn_id,
+                        job_location,
+                        _DATASET_LABELS_SQL.format(project=project, region_path=region_path),
+                        f"SCHEMATA_OPTIONS {tag}",
+                    )
+                ] = tag
+
+    storage_dfs: List[pd.DataFrame] = []
+    for future in as_completed(storage_futures):
+        df = future.result()
+        if df is not None and not df.empty:
+            storage_dfs.append(df)
+
+    labels_dfs: List[pd.DataFrame] = []
+    for future in as_completed(labels_futures):
+        df = future.result()
+        if df is not None and not df.empty:
+            labels_dfs.append(df)
+
+    combined_storage = pd.concat(storage_dfs, ignore_index=True) if storage_dfs else pd.DataFrame()
+    combined_labels = pd.concat(labels_dfs, ignore_index=True) if labels_dfs else pd.DataFrame()
+
+    if combined_storage.empty:
+        raise RuntimeError(
+            "TABLE_STORAGE returned zero rows across all project/region "
+            "combinations — cannot proceed with latency checks"
+        )
+
+    logging.info(
+        "📊 Collected %d TABLE_STORAGE rows, %d dataset label rows",
+        len(combined_storage),
+        len(combined_labels),
+    )
+
+    _write_staging_table(
+        df=combined_storage,
+        table_id=f"{dest_project}.{dest_dataset}._latency_staging_table_storage",
+        gcp_conn_id=gcp_conn_id,
+        location="us-central1",
+    )
+    _write_staging_table(
+        df=combined_labels if not combined_labels.empty else pd.DataFrame({"schema_name": pd.Series(dtype="str")}),
+        table_id=f"{dest_project}.{dest_dataset}._latency_staging_dataset_labels",
+        gcp_conn_id=gcp_conn_id,
+        location="us-central1",
+    )
+
+    return {
+        "table_storage_rows": len(combined_storage),
+        "dataset_labels_rows": len(combined_labels),
+    }
+
+
+def _write_staging_table(
+    df: pd.DataFrame,
+    table_id: str,
+    gcp_conn_id: str,
+    location: str,
+) -> None:
+    """Write a DataFrame to a BigQuery table with WRITE_TRUNCATE."""
+    hook = BigQueryHook(gcp_conn_id=gcp_conn_id, location=location, use_legacy_sql=False)
+    client = hook.get_client(project_id=table_id.split(".")[0])
+
+    job_config = LoadJobConfig(write_disposition=WriteDisposition.WRITE_TRUNCATE)
+    load_job = client.load_table_from_dataframe(df, table_id, job_config=job_config)
+    load_job.result()
+
+    logging.info("✅ Wrote %d rows to %s", len(df), table_id)
+
 
 # Slack routing edge cases (documented per requirements):
 # - Duplicate regex patterns


### PR DESCRIPTION
## Summary

- **Expanded monitoring scope**: Added Daton connector tables (`%daton%`), BQ custom tables (`%BQ%`), and `nexus_gds_raw` alongside existing `_prod_raw` tables across all 6 projects (insightsprod, pulse-wellbeam, pulse-instanthydration, pulse-mantasleep, pulse-javvycoffee, pulse-nexus)
- **Cross-region metadata collection**: Replaced single-region `INFORMATION_SCHEMA` queries with a Python-based metadata collector that queries both `region-us-central1` and `region-us` per project using `BigQueryHook` with the correct job location, solving the `404 Not Found` error for cross-region access
- **Optimized latency evaluation**: Consolidated the UNION ALL + `daton_pattern_matched` CTE approach into a single-pass LEFT JOIN with `COALESCE` for the default 24-hour threshold, reducing `deduped_table_storage` scans from 3x to 1x

## Changes

### `dags/utils.py`
- Added `collect_cross_region_metadata()` function that queries `INFORMATION_SCHEMA.TABLE_STORAGE` and `SCHEMATA_OPTIONS` for every (project, region) combination in parallel using `ThreadPoolExecutor` (6 workers)
- Gracefully handles 404 errors for projects without datasets in a given region
- Writes combined results to two staging tables (`_latency_staging_table_storage`, `_latency_staging_dataset_labels`) via `load_table_from_dataframe()` with `WRITE_TRUNCATE`
- Fails with `RuntimeError` if TABLE_STORAGE returns zero rows across all combinations

### `dags/query.sql`
- Replaced Jinja-templated `{% for project %}` loops with reads from pre-collected staging tables (query is now pure SQL, no Jinja)
- Added schema filters: `%daton%`, `%BQ%` in both `deduped_table_storage` and `matched_tables`
- Added dataset exclusions (global and project-scoped) for backup, staging, and deprecated datasets
- Excluded `daton_metadata` table across all datasets
- Optimized matched_tables: single LEFT JOIN to patterns with `COALESCE(p.latency_threshold, 24)` instead of UNION ALL
- Narrowed `table_storage_all` to only required columns instead of `SELECT *` from INFORMATION_SCHEMA

### `dags/data_latency_alerts_dag.py`
- Added `collect_metadata` PythonOperator task as the first step in the DAG
- Updated task flow: `collect_metadata >> run_latency_sql >> run_latency_check >> convert_to_xlsx >> send_notification`
- `send_notification` task covers failures from all upstream tasks including the new metadata collection

### `README.md`
- Full rewrite reflecting the current architecture, cross-region collection, SQL query flow, configuration, and troubleshooting

## Dataset Exclusions

**Global exclusions** (all projects): `daton_healthycell_kr`, `DatonPearlWestGroup`, `IH_Daton`, `daton_eskiin_custom_backup`, `lhappyinnov_daton_backup`, `marketdefense_daton_staging`, `wellbeam_daton_backup`

**Project-scoped exclusions**:
- `insightsprod`: `Manta_Daton`, `daton_instanthydrati`, `daton_javvycofee`, `wellbeam_daton`
- `pulse-instanthydration`: `daton_instanthydrati`

**Table-level exclusion**: `daton_metadata` (across all datasets)

## Test Plan

- [x] Verify `collect_metadata` task completes successfully and staging tables are populated with data from both `region-us-central1` and `region-us`
- [x] Verify `run_latency_sql` task reads from staging tables and produces correct violations in `raw_table_latency_failure_details`
- [x] Confirm Daton tables (e.g., `trueseamoss_daton`, `pavoi_daton_custom`) appear in reports when exceeding 24h threshold
- [x] Confirm BQ tables (e.g., `Homefield_BQ`, `Warmies_BQ`) appear in reports when exceeding 24h threshold
- [x] Confirm excluded datasets and `daton_metadata` table do NOT appear in reports
- [x] Verify Slack notifications route correctly to client-specific channels
- [x] Verify failure notification fires if `collect_metadata` task fails
